### PR TITLE
Replace Signature Event with Intern Day

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ You can find all of this on Glassdoor, but for the sake of shoving all relevant 
    - $7700/mo
    - $5000 gross starting bonus
    
-Additionally, all Redmond interns receive free corporate housing OR a $7000 net housing stipend, a subsidized car rental OR a $1200 net transportation stipend, a $300 net misc expenses stipend (read: pays for checked bags and shipping), a bus pass for the Seattle metro area, reimbursed gym membership, free healthcare (no dental for interns), access to the Connector shuttles to and from work, the Signature Event gift, and more.
+Additionally, all Redmond interns receive free corporate housing OR a $7000 net housing stipend, a subsidized car rental OR a $1200 net transportation stipend, a $300 net misc expenses stipend (read: pays for checked bags and shipping), a bus pass for the Seattle metro area, reimbursed gym membership, free healthcare (no dental for interns), access to the Connector shuttles to and from work, Intern Day (which has replaced the Signature Event), and more.
 
 After accounting for California taxes and cost of living differences, my personal opinions is that for **internships**, Microsoft HQ offers are marginally more competitive than Google HQ offers and on par with Facebook HQ offers.
 
@@ -106,7 +106,10 @@ You could end up in a Hilton with breakfast every morning, or you could end up i
 ## Car Rentals
 Are you gonna travel to music festivals or go hiking every weekend? If so, you should take the car option. If not, Puget Sound public transit + the Connector is more than enough.
 
-## Signature Event
+## Intern Day
+Intern Day was new in the summer of 2019, replacing the Signature Event. It was an all-day event with a few speakers in the morning, including the CEO Satya Nadella, followed by food trucks, lawn games, a beer garden, indoor activities, and a concert.
+
+### Signature Event (replaced by Intern Day)
 The sig event is a festival of activities and a concert every year held at a landmark venue in the Seattle metro area, and also the night the "intern gift" is given; it's a major distinguishing factor between competitors' internships and Microsoft internships. 
 
 Some examples; in 2016, the sig event was Ellie Goulding at Seattle Center (Space Needle and the Chihuly Museum were shut down for us) and the gift was a maxxed out Surface Book (retail ~$1900/person). In 2017, it was Daya and The Chainsmokers at the Boeing Factory/Museum/Runway in Mukilteo (the concert was on an active runway) and the gift was an Xbox (retail $250/person).


### PR DESCRIPTION
Intern Day is the new replacement for the Signature Event. I added information on Intern Day and kept the info about the Signature Event for reference.